### PR TITLE
handle java projects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,45 +16,27 @@ inThisBuild(
 
 lazy val testSettings: Seq[Setting[_]] = Seq(
   scriptedLaunchOpts := {
-    scriptedLaunchOpts.value ++
-      Seq("-Xmx1024M", "-Dplugin.version=" + version.value)
+    scriptedLaunchOpts.value ++ Seq(
+      "-Xmx1024M",
+      "-XX:MaxPermSize=256M",
+      "-Dplugin.version=" + version.value
+    )
   },
-  scriptedBufferLog := false,
-  test := {
-    (Test / test).value
-    scripted.toTask("").value
-  }
+  scriptedBufferLog := false
 )
 
 lazy val core = project
   .in(file("core"))
-  .enablePlugins(SbtPlugin)
-  .settings(
-    name := "sbt-codeartifact-core",
-    libraryDependencies ++= Seq(
-      "software.amazon.awssdk" % "codeartifact" % "2.16.10"
-    )
-  )
   .settings(testSettings)
 
-lazy val sbtcodeartifact = project
+lazy val `sbt-codeartifact` = project
   .in(file("sbt-codeartifact"))
-  .enablePlugins(SbtPlugin)
   .dependsOn(core)
-  .settings(
-    name := "sbt-codeartifact",
-    scalacOptions -= "-Xfatal-warnings",
-    pluginCrossBuild / sbtVersion := {
-      scalaBinaryVersion.value match {
-        case "2.12" => "1.2.8" // set minimum sbt version
-      }
-    }
-  )
   .settings(testSettings)
 
 lazy val root = project
   .in(file("."))
-  .aggregate(core, sbtcodeartifact)
+  .aggregate(core, `sbt-codeartifact`)
   .settings(
     publish / skip := true
   )

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -1,0 +1,10 @@
+enablePlugins(SbtPlugin)
+
+name := "sbt-codeartifact-core"
+
+libraryDependencies ++= Seq(
+  "software.amazon.awssdk" % "codeartifact" % "2.16.10",
+  "com.lihaoyi" %% "utest" % "0.7.7" % Test
+)
+
+testFrameworks += new TestFramework("utest.runner.Framework")

--- a/core/src/test/scala/codeartifact/CodeArtifactPackageSpec.scala
+++ b/core/src/test/scala/codeartifact/CodeArtifactPackageSpec.scala
@@ -1,0 +1,24 @@
+package codeartifact
+
+import utest._
+
+object CodeArtifactPackageSpec extends TestSuite {
+
+  val PackageVersion = "1.2.3"
+  val ScalaVersion = "3.2.1"
+  val basePackage = CodeArtifactPackage("org", "name", PackageVersion, ScalaVersion, None, true)
+
+  val tests = Tests {
+    test("asMaven") {
+      test("scala") {
+        basePackage.asMaven ==> "name_3.2"
+      }
+      test("java") {
+        basePackage.copy(isScalaProject = false).asMaven ==> "name"
+      }
+      test("sbt") {
+        basePackage.copy(sbtBinaryVersion = Some("1.0")).asMaven ==> "name_3.2_1.0"
+      }
+    }
+  }
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.5.0

--- a/sbt-codeartifact/build.sbt
+++ b/sbt-codeartifact/build.sbt
@@ -1,0 +1,18 @@
+enablePlugins(SbtPlugin)
+
+name := "sbt-codeartifact"
+
+// Unfortunately, there's an issue where the Scala compiler is
+// erroneously warning on valid SBT syntax.
+scalacOptions -= "-Xfatal-warnings"
+
+pluginCrossBuild / sbtVersion := {
+  scalaBinaryVersion.value match {
+    case "2.12" => "1.2.8" // set minimum sbt version
+  }
+}
+
+test := {
+  (Test / test).value
+  scripted.toTask("").value
+}

--- a/sbt-codeartifact/src/main/scala/codeartifact/CodeArtifactPlugin.scala
+++ b/sbt-codeartifact/src/main/scala/codeartifact/CodeArtifactPlugin.scala
@@ -34,8 +34,9 @@ object CodeArtifactPlugin extends AutoPlugin {
       name = name.value,
       version = version.value,
       scalaVersion = scalaVersion.value,
-      isSbtPlugin = sbtPlugin.value,
-      sbtBinaryVersion = sbtBinaryVersion.value
+      sbtBinaryVersion = if (sbtPlugin.value) Some(sbtBinaryVersion.value) else None,
+      // See: https://www.scala-sbt.org/1.x/docs/Cross-Build.html#Scala-version+specific+source+directory
+      isScalaProject = crossPaths.value
     ),
     publishTo := Some(codeArtifactRepo.value.resolver),
     publishMavenStyle := true,


### PR DESCRIPTION
If someone wants to publish a java library via sbt, they will set `crossPaths` to `false`. In that case, we won't want to append the scala binary version.