### PR TITLE
use http api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # SBT CodeArtifact
 
-[![Maven][maven]][mavenLink]
+[![Maven][maven]][mavenlink]
 
 [maven]: https://maven-badges.herokuapp.com/maven-central/io.github.bbstilson/sbt-codeartifact/badge.svg?kill_cache=1&color=blue&style=for-the-badge
-[mavenLink]: https://search.maven.org/search?q=g:io.github.bbstilson%20AND%20a:sbt-codeartifact
+[mavenlink]: https://search.maven.org/search?q=g:io.github.bbstilson%20AND%20a:sbt-codeartifact
 
 An sbt plugin for publishing/consuming packages to/from AWS CodeArtifact.
 
@@ -77,7 +77,13 @@ sbt:library> show resolvers
 
 ## Credentials
 
-Credentials are resolved using the [DefaultCredentialsProvider](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/auth/credentials/DefaultCredentialsProvider.html).
+Your CodeArtifact Authentication Token is fetched dynamically using the AWS Java SDK. Credentials are resolved using the [DefaultCredentialsProvider](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/auth/credentials/DefaultCredentialsProvider.html).
+
+If you would like to provide the token statically (for example, if your AWS creds are unavailable), then you can provide the token as an environment variable:
+
+```bash
+export CODEARTIFACT_AUTH_TOKEN=`aws codeartifact get-authorization-token --domain domain-name --domain-owner domain-owner-id --query authorizationToken --output text --profile profile-name`
+```
 
 ## SBT Release
 

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -4,6 +4,8 @@ name := "sbt-codeartifact-core"
 
 libraryDependencies ++= Seq(
   "software.amazon.awssdk" % "codeartifact" % "2.16.10",
+  "com.lihaoyi" %% "requests" % "0.6.5",
+  "com.lihaoyi" %% "os-lib" % "0.7.3",
   "com.lihaoyi" %% "utest" % "0.7.7" % Test
 )
 

--- a/core/src/main/scala/codeartifact/CodeArtifact.scala
+++ b/core/src/main/scala/codeartifact/CodeArtifact.scala
@@ -1,114 +1,39 @@
 package codeartifact
 
-import sbt._
-
 import software.amazon.awssdk.services.codeartifact.CodeartifactClient
-import software.amazon.awssdk.services.codeartifact.model.{
-  GetAuthorizationTokenRequest,
-  ListPackageVersionsRequest,
-  PackageFormat,
-  PackageVersionStatus,
-  UpdatePackageVersionsStatusRequest
-}
+import software.amazon.awssdk.services.codeartifact.model.GetAuthorizationTokenRequest
 
-import collection.JavaConverters._
-
-class CodeArtifact(
-  repo: CodeArtifactRepo,
-  pkg: CodeArtifactPackage,
-  logger: Logger
-) {
-  private val client = CodeartifactClient.create()
-
-  private val getAuthorizationTokenRequest = GetAuthorizationTokenRequest
-    .builder()
-    .domain(repo.domain)
-    .domainOwner(repo.owner)
-    .durationSeconds(900L) // 15 minutes
-    .build()
-
-  private val listPackageVersionsRequest = ListPackageVersionsRequest
-    .builder()
-    .domain(repo.domain)
-    .domainOwner(repo.owner)
-    .format(PackageFormat.MAVEN)
-    .namespace(pkg.organization)
-    .repository(repo.name)
-    .packageValue(pkg.asMaven)
-    .build()
-
-  private val updatePackageVersionStatusRequest = UpdatePackageVersionsStatusRequest
-    .builder()
-    .domain(repo.domain)
-    .domainOwner(repo.owner)
-    .format(PackageFormat.MAVEN)
-    .repository(repo.name)
-    .namespace(pkg.organization)
-    .packageValue(pkg.asMaven)
-    .versions(pkg.version)
-    .targetStatus(PackageVersionStatus.PUBLISHED)
-    .build()
-
-  val credentials: Credentials = Credentials(
-    realm = repo.realm,
-    host = repo.host,
-    userName = "aws",
-    passwd = getAuthToken
-  )
-
-  private def getAuthToken: String = client
-    .getAuthorizationToken(getAuthorizationTokenRequest)
-    .authorizationToken()
-
-  def getPackageVersions: List[String] =
-    client
-      .listPackageVersions(listPackageVersionsRequest)
-      .versions()
-      .asScala
-      .toList
-      .map(_.version())
-
-  def updatePackageVersionStatus(): Unit = {
-    val resp = client
-      .updatePackageVersionsStatus(updatePackageVersionStatusRequest)
-
-    val failedVersions = resp.failedVersions().asScala.toMap
-    if (failedVersions.nonEmpty) {
-      failedVersions.foreach { case (k, err) =>
-        logger.error(s"$k - ${err.errorCodeAsString()}:  ${err.errorMessage()}")
-      }
-      sys.error("Did not successfully update packages.")
-    }
-
-    resp.successfulVersions().asScala.foreach { case (version, success) =>
-      // Published - library_2.1x a.b.c
-      logger.info(s"${success.statusAsString()} - ${pkg.asMaven} $version")
-    }
-  }
-
-  def waitForPackageAvailable(
-    attempts: Int = 0
-  ): Unit = {
-    if (!getPackageVersions.contains(pkg.version)) {
-      if (attempts > CodeArtifact.MAX_RETRY) {
-        sys.error(
-          "Unable to resolve package in CodeArtifacts. Please check for errors and try again."
-        )
-      } else {
-
-        println(
-          s"Package not available yet... Will check again in ${CodeArtifact.REQUEST_DELAY}ms."
-        )
-        Thread.sleep(CodeArtifact.REQUEST_DELAY)
-        waitForPackageAvailable(attempts + 1)
-      }
-    }
-  }
-
-}
+import sbt._
+import scala.concurrent.duration._
 
 object CodeArtifact {
-  private[codeartifact] val REQUEST_DELAY = 2000L // 2 seconds
-  // Will wait up to 30 seconds before giving up.
-  private[codeartifact] val MAX_RETRY = 15
+
+  def mkCredentials(repo: CodeArtifactRepo, token: String): Credentials = Credentials(
+    userName = "aws",
+    realm = repo.realm,
+    host = repo.host,
+    passwd = token
+  )
+
+  private def getAuthorizationTokenRequest(domain: String, owner: String) =
+    GetAuthorizationTokenRequest
+      .builder()
+      .domain(domain)
+      .domainOwner(owner)
+      .durationSeconds(15.minutes.toSeconds)
+      .build()
+
+  private def getAuthTokenFromRequest(req: GetAuthorizationTokenRequest): String =
+    CodeartifactClient
+      .create()
+      .getAuthorizationToken(req)
+      .authorizationToken()
+
+  def getAuthToken(repo: CodeArtifactRepo): String =
+    getAuthTokenFromRequest(getAuthorizationTokenRequest(repo.domain, repo.owner))
+
+  object Defaults {
+    val READ_TIMEOUT: Int = 1.minutes.toMillis.toInt
+    val CONNECT_TIMEOUT: Int = 5.seconds.toMillis.toInt
+  }
 }

--- a/core/src/main/scala/codeartifact/CodeArtifactApi.scala
+++ b/core/src/main/scala/codeartifact/CodeArtifactApi.scala
@@ -1,0 +1,29 @@
+package codeartifact
+
+import scala.concurrent.duration._
+
+final class CodeArtifactApi(
+  token: String,
+  readTimeout: Int,
+  connectTimeout: Int
+) {
+
+  private val http = requests.Session(
+    readTimeout = readTimeout,
+    connectTimeout = connectTimeout,
+    maxRedirects = 0,
+    check = false
+  )
+
+  private val uploadTimeout = 5.minutes.toMillis.toInt
+
+  def upload(uri: String, data: Array[Byte]): requests.Response = {
+    http.put(
+      uri,
+      readTimeout = uploadTimeout,
+      headers = Seq("Content-Type" -> "application/octet-stream"),
+      auth = new requests.RequestAuth.Basic("aws", token),
+      data = data
+    )
+  }
+}

--- a/core/src/main/scala/codeartifact/CodeArtifactPackage.scala
+++ b/core/src/main/scala/codeartifact/CodeArtifactPackage.scala
@@ -1,5 +1,9 @@
 package codeartifact
 
+import java.time.format.DateTimeFormatter
+import java.time.ZoneId
+import java.time.Instant
+
 final case class CodeArtifactPackage(
   organization: String,
   name: String,
@@ -11,8 +15,6 @@ final case class CodeArtifactPackage(
 
   def asMaven: String = {
     // We only want to append the scala binary version if we are publishing a scala library.
-    // This can be deterined by the `crossPaths` sbt flag, for example.
-    // See: https://www.scala-sbt.org/1.x/docs/Cross-Build.html#Scala-version+specific+source+directory
     val mvn = if (isScalaProject) {
       sbt.CrossVersion
         .partialVersion(scalaVersion)
@@ -27,4 +29,27 @@ final case class CodeArtifactPackage(
       .getOrElse(mvn)
   }
 
+  def basePublishPath: String = s"${organization.replace(".", "/")}/$asMaven"
+  def versionPublishPath: String = s"$basePublishPath/$version"
+
+  private def currentTimeNumber() =
+    DateTimeFormatter
+      .ofPattern("yyyyMMddHHmmss")
+      .withZone(ZoneId.systemDefault())
+      .format(Instant.now())
+
+  def mavenMetadata: String = {
+    <metadata modelVersion="1.1.0">
+      <groupId>{organization}</groupId>
+      <artifactId>{asMaven}</artifactId>
+      <versioning>
+        <latest>{version}</latest>
+        <release>{version}</release>
+        <versions>
+          <version>{version}</version>
+        </versions>
+        <lastUpdated>{currentTimeNumber()}</lastUpdated>
+      </versioning>
+    </metadata>
+  }.buildString(stripComments = true)
 }

--- a/core/src/test/scala/codeartifact/CodeArtifactPackageSpec.scala
+++ b/core/src/test/scala/codeartifact/CodeArtifactPackageSpec.scala
@@ -6,7 +6,9 @@ object CodeArtifactPackageSpec extends TestSuite {
 
   val PackageVersion = "1.2.3"
   val ScalaVersion = "3.2.1"
-  val basePackage = CodeArtifactPackage("org", "name", PackageVersion, ScalaVersion, None, true)
+
+  val basePackage =
+    CodeArtifactPackage("org.example", "name", PackageVersion, ScalaVersion, None, true)
 
   val tests = Tests {
     test("asMaven") {
@@ -19,6 +21,17 @@ object CodeArtifactPackageSpec extends TestSuite {
       test("sbt") {
         basePackage.copy(sbtBinaryVersion = Some("1.0")).asMaven ==> "name_3.2_1.0"
       }
+    }
+
+    test("versionPublishPath") {
+      basePackage.versionPublishPath ==> "org/example/name_3.2/1.2.3"
+    }
+
+    test("mavenMetadata") {
+      val xml = scala.xml.XML.loadString(basePackage.mavenMetadata)
+      (xml \ "groupId").head.text ==> basePackage.organization
+      (xml \ "artifactId").head.text ==> basePackage.asMaven
+      (xml \ "versioning" \ "latest").head.text ==> basePackage.version
     }
   }
 }

--- a/sbt-codeartifact/src/main/scala/codeartifact/CodeArtifactKeys.scala
+++ b/sbt-codeartifact/src/main/scala/codeartifact/CodeArtifactKeys.scala
@@ -20,15 +20,14 @@ trait CodeArtifactKeys {
 }
 
 trait InternalCodeArtifactKeys {
-  val codeArtifact = taskKey[CodeArtifact]("Covenience wrapper around a repo and package.")
+  val codeArtifactReadTimeout = taskKey[Int]("API request read timeout. Defaults to 1 minute.")
+  val codeArtifactConnectTimeout = taskKey[Int]("API request read timeout. Defaults to 30 seconds.")
   val codeArtifactRepo = taskKey[CodeArtifactRepo]("CodeArtifact repository.")
   val codeArtifactPackage = taskKey[CodeArtifactPackage]("CodeArtifact package.")
 
-  val codeArtifactWaitForPackageAvailable =
-    taskKey[Unit]("Waits for the package to be availble so that the status can be updated.")
-
-  val codeArtifactUpdateStatus =
-    taskKey[Unit]("Updates the package status to Published.")
+  val codeArtifactToken = taskKey[String](
+    "CodeArtifact authentication. Provided by environment variable CODEARTIFACT_AUTH_TOKEN or fetched dynamically from available AWS credentials."
+  )
 }
 
 object CodeArtifactKeys extends CodeArtifactKeys

--- a/sbt-codeartifact/src/main/scala/codeartifact/CodeArtifactPlugin.scala
+++ b/sbt-codeartifact/src/main/scala/codeartifact/CodeArtifactPlugin.scala
@@ -2,6 +2,7 @@ package codeartifact
 
 import sbt._
 import sbt.Keys._
+import sbt.internal.util.ManagedLogger
 
 object CodeArtifactPlugin extends AutoPlugin {
   import CodeArtifactKeys._
@@ -20,15 +21,15 @@ object CodeArtifactPlugin extends AutoPlugin {
   )
 
   def codeArtifactSettings: Seq[Setting[_]] = Seq(
-    codeArtifact := new CodeArtifact(
-      codeArtifactRepo.value,
-      codeArtifactPackage.value,
-      streams.value.log
-    ),
-    codeArtifactWaitForPackageAvailable := codeArtifact.value.waitForPackageAvailable(),
-    codeArtifactUpdateStatus := codeArtifact.value.updatePackageVersionStatus(),
     codeArtifactPublish := dynamicallyPublish.value,
     codeArtifactRepo := CodeArtifactRepo.fromUrl(codeArtifactUrl.value),
+    codeArtifactToken := sys.env
+      .getOrElse(
+        "CODEARTIFACT_AUTH_TOKEN",
+        CodeArtifact.getAuthToken(codeArtifactRepo.value)
+      ),
+    codeArtifactConnectTimeout := CodeArtifact.Defaults.CONNECT_TIMEOUT,
+    codeArtifactReadTimeout := CodeArtifact.Defaults.READ_TIMEOUT,
     codeArtifactPackage := CodeArtifactPackage(
       organization = organization.value,
       name = name.value,
@@ -38,12 +39,12 @@ object CodeArtifactPlugin extends AutoPlugin {
       // See: https://www.scala-sbt.org/1.x/docs/Cross-Build.html#Scala-version+specific+source+directory
       isScalaProject = crossPaths.value
     ),
+    credentials += CodeArtifact.mkCredentials(codeArtifactRepo.value, codeArtifactToken.value),
     publishTo := Some(codeArtifactRepo.value.resolver),
     publishMavenStyle := true,
-    credentials += codeArtifact.value.credentials,
     // Useful for consuming artifacts.
     resolvers += CodeArtifactRepo.fromUrl(codeArtifactUrl.value).resolver
-  ) ++ dependencyOrdering
+  )
 
   // Uses taskDyn because it can return one of two potential tasks
   // as its result, each with their own dependencies.
@@ -54,32 +55,62 @@ object CodeArtifactPlugin extends AutoPlugin {
     val ref = thisProjectRef.value
 
     if (shouldSkip) Def.task {
-      logger.debug(s"skipping publish for ${ref.project}")
+      logger.debug(s"Skipping publish for ${ref.project}")
     }
-    else
+    else {
       Def.task {
-        // First, do a normal publish.
-        publish.value
-        // Then, wait for the package to be available on CodeArtifact.
-        codeArtifactWaitForPackageAvailable.value
-        // Then, manually update the status.
-        // See: https://docs.aws.amazon.com/codeartifact/latest/ug/packages-overview.html#package-version-status
-        codeArtifactUpdateStatus.value
+        val logger = streams.value.log
+        val api = new CodeArtifactApi(
+          codeArtifactToken.value,
+          readTimeout = codeArtifactReadTimeout.value,
+          connectTimeout = codeArtifactConnectTimeout.value
+        )
+        val url = codeArtifactUrl.value.stripSuffix("/")
+        val pkg = codeArtifactPackage.value
+        val basePublishPath = pkg.basePublishPath
+        val versionPublishPath = pkg.versionPublishPath
+
+        val files = packagedArtifacts.value.toList
+          // Drop Artifact.
+          .map { case (_, file) => file }
+          // Convert to os.Path.
+          .map(file => os.Path(file))
+          // Create CodeArtifact file name.
+          .map(file => s"$versionPublishPath/${file.last}" -> file)
+
+        val metadataFile = {
+          val td = os.temp.dir()
+          os.write(td / "maven-metadata.xml", codeArtifactPackage.value.mavenMetadata)
+          val file = td / "maven-metadata.xml"
+          s"$basePublishPath/${file.last}" -> file
+        }
+
+        val responses = (files :+ metadataFile)
+          .map { case (fileName, file) =>
+            logger.info(s"Uploading $fileName")
+            api.upload(s"$url/$fileName", os.read.bytes(file))
+          }
+
+        reportPublishResults(responses, logger)
       }
+    }
   }
 
-  def dependencyOrdering: Seq[Setting[_]] = Seq(
-    // Although the body of codeArtifactPublish above seems ordered, tasks in the task graph
-    // can/will be executed in parallel if they can be. The following few lines define some
-    // ordering requirements.
-    //
-    // We can only wait for the package to be available after it has finished publishing.
-    codeArtifactWaitForPackageAvailable := codeArtifactWaitForPackageAvailable
-      .dependsOn(publish)
-      .value,
-    // We can only update the package status after it is made available.
-    codeArtifactUpdateStatus := codeArtifactUpdateStatus
-      .dependsOn(codeArtifactWaitForPackageAvailable)
-      .value
-  )
+  private def reportPublishResults(
+    publishResults: Seq[requests.Response],
+    logger: ManagedLogger
+  ) = {
+    if (publishResults.forall(_.is2xx)) {
+      logger.info(s"Successfully published to AWS Codeartifact")
+    } else {
+      val errors = publishResults
+        .filterNot(_.is2xx)
+        .map { response =>
+          s"Code: ${response.statusCode}, message: ${response.text()}"
+        }
+        .mkString("\n")
+
+      throw new RuntimeException(s"Failed to publish to AWS Codeartifact. Errors: \n$errors")
+    }
+  }
 }


### PR DESCRIPTION
This is a pretty significant refactor away from the default publishing process towards using the http api. This approach solves a few problems, primarily the fact that sbt publishing does not upload maven metadata. There's [a plugin](https://github.com/sbt/sbt-maven-resolver), but it seems like it has [some issues](https://github.com/NicolasRouquette/sbt.mavenResolverPlugin.problem) with generating that file. This meant that we previously had to manually flip the package's status in CodeArtifact from Unpublished to Published when it became available, which always felt like a hack (because it was).

I tested locally by publishing a fake library library to my personal codeartifact repo, and I added another test for the metadata:

<img width="1432" alt="Screen Shot 2021-04-12 at 10 42 01 PM" src="https://user-images.githubusercontent.com/7949037/114502343-7c943780-9be0-11eb-99c0-132715d487a1.png">

And with a "java" library, by setting "crossPaths := false":

<img width="1436" alt="Screen Shot 2021-04-12 at 10 44 07 PM" src="https://user-images.githubusercontent.com/7949037/114502476-b1a08a00-9be0-11eb-9627-06fd220975b8.png">

Notice both have status Published, and the java version is missing the Scala binary version.