### PR TITLE
add key for consuming additional repos

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,3 +31,5 @@ jobs:
         run: sbt test
         env:
           AWS_REGION: us-west-2
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,22 +13,21 @@ jobs:
         java-version: [8, 11]
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Set up JDK & sbt
-      uses: olafurpg/setup-scala@v10
-      with:
-        java-version: ${{ matrix.java-version }}
+      - name: Set up JDK & sbt
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: ${{ matrix.java-version }}
 
-    - name: Run scalafmt
-      run: |
-        sbt scalafmtCheckAll
+      - name: Run scalafmt
+        run: sbt scalafmtCheckAll
 
-    - name: Run scalafmt sbt
-      run: |
-        sbt scalafmtSbtCheck
+      - name: Run scalafmt sbt
+        run: sbt scalafmtSbtCheck
 
-    - name: Run tests
-      run: |
-        sbt test
+      - name: Run tests
+        run: sbt test
+        env:
+          AWS_REGION: us-west-2

--- a/README.md
+++ b/README.md
@@ -52,24 +52,17 @@ sbt:library> codeArtifactPublish
 A resolver for your repository is added based on the `codeArtifactUrl` key. You can add more repositories manually like so:
 
 ```scala
-def mkCodeArtifactRepoUrl(name: String): String =
-  s"https://com-example-1234567890.d.codeartifact.us-west-2.amazonaws.com/maven/$name"
+val codeArtifactUrlBase = "https://com-example-1234567890.d.codeartifact.us-west-2.amazonaws.com/maven/"
 
-val additional = List("foo", "superfoo", "other")
-
-codeArtifactUrl := mkCodeArtifactRepoUrl("private")
-
-resolvers ++= additional
-  .map(mkCodeArtifactRepoUrl)
-  .map(codeartifact.CodeArtifactRepo.fromUrl)
-  .map(_.resolver)
+codeArtifactUrl := codeArtifactUrlBase + "release"
+codeArtifactResolvers := List("foo", "bar", "baz").map(repo => codeArtifactUrlBase + repo)
 ```
 
 In sbt:
 
 ```plaintext
 sbt:library> show resolvers
-[info] * com-example/private: https://com-example-1234567890.d.codeartifact.us-west-2.amazonaws.com/maven/private
+[info] * com-example/private: https://com-example-1234567890.d.codeartifact.us-west-2.amazonaws.com/maven/release
 [info] * com-example/foo: https://com-example-1234567890.d.codeartifact.us-west-2.amazonaws.com/maven/foo
 [info] * com-example/superfoo: https://com-example-1234567890.d.codeartifact.us-west-2.amazonaws.com/maven/superfoo
 [info] * com-example/other: https://com-example-1234567890.d.codeartifact.us-west-2.amazonaws.com/maven/other

--- a/core/src/main/scala/codeartifact/CodeArtifact.scala
+++ b/core/src/main/scala/codeartifact/CodeArtifact.scala
@@ -8,7 +8,7 @@ import scala.concurrent.duration._
 
 object CodeArtifact {
 
-  def mkCredentials(repo: CodeArtifactRepo, token: String): Credentials = Credentials(
+  def mkCredentials(token: String)(repo: CodeArtifactRepo): Credentials = Credentials(
     userName = "aws",
     realm = repo.realm,
     host = repo.host,

--- a/sbt-codeartifact/src/main/scala/codeartifact/CodeArtifactKeys.scala
+++ b/sbt-codeartifact/src/main/scala/codeartifact/CodeArtifactKeys.scala
@@ -17,6 +17,9 @@ trait CodeArtifactKeys {
 
   val codeArtifactUrl: SettingKey[String] =
     settingKey[String]("CodeArtifact connection url.")
+
+  val codeArtifactResolvers: SettingKey[List[String]] =
+    settingKey[List[String]]("Additional CodeArtifact repos from which to consume packages.")
 }
 
 trait InternalCodeArtifactKeys {

--- a/sbt-codeartifact/src/sbt-test/sbt-codeartifact/appends-creds/build.sbt
+++ b/sbt-codeartifact/src/sbt-test/sbt-codeartifact/appends-creds/build.sbt
@@ -17,11 +17,11 @@ lazy val checkResolversAndCredentials = taskKey[Unit](
 
 checkResolversAndCredentials := {
   val repos = resolvers.value.map(_.name)
-  val creds = credentials.value
+  val creds = credentials.value.map(_.toString())
 
   assert(repos.size == 2, "CodeArtifact resolvers were not added.")
   assert(creds.size == 2, "CodeArtifact credentials were not added.")
-  assert(creds.head.toString() == creds.last.toString(), "Credentials did not match.")
+  assert(creds.head == creds.last, "Credentials did not match.")
   assert(repos.head == repos.last, "Resolvers did not match.")
 
   streams.value.log.success("Added credentials and resolvers.")

--- a/sbt-codeartifact/src/sbt-test/sbt-codeartifact/appends-creds/build.sbt
+++ b/sbt-codeartifact/src/sbt-test/sbt-codeartifact/appends-creds/build.sbt
@@ -1,0 +1,28 @@
+name := "resolver-test"
+scalaVersion := "2.13.5"
+
+// This is a real url, and it must be, but only I'll be able to
+// use it since only I have the aws creds to get an auth token.
+val repoUrl = "https://bbstilson-968410040515.d.codeartifact.us-west-2.amazonaws.com/maven/test/"
+
+codeArtifactUrl := repoUrl
+// Adding the same repo again.
+// We should see the same credentials and resolvers twice.
+codeArtifactResolvers := List(repoUrl)
+
+lazy val checkResolversAndCredentials = taskKey[Unit](
+  "Ensures that resolvers and credentials are added for the" +
+    "codeArtifactUrl repo and any repos added via codeArtifactResolvers."
+)
+
+checkResolversAndCredentials := {
+  val repos = resolvers.value.map(_.name)
+  val creds = credentials.value
+
+  assert(repos.size == 2, "CodeArtifact resolvers were not added.")
+  assert(creds.size == 2, "CodeArtifact credentials were not added.")
+  assert(creds.head.toString() == creds.last.toString(), "Credentials did not match.")
+  assert(repos.head == repos.last, "Resolvers did not match.")
+
+  streams.value.log.success("Added credentials and resolvers.")
+}

--- a/sbt-codeartifact/src/sbt-test/sbt-codeartifact/appends-creds/project/build.properties
+++ b/sbt-codeartifact/src/sbt-test/sbt-codeartifact/appends-creds/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.5.0

--- a/sbt-codeartifact/src/sbt-test/sbt-codeartifact/appends-creds/project/plugins.sbt
+++ b/sbt-codeartifact/src/sbt-test/sbt-codeartifact/appends-creds/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("io.github.bbstilson" % "sbt-codeartifact" % System.getProperty("plugin.version"))

--- a/sbt-codeartifact/src/sbt-test/sbt-codeartifact/appends-creds/test
+++ b/sbt-codeartifact/src/sbt-test/sbt-codeartifact/appends-creds/test
@@ -1,0 +1,1 @@
+> checkResolversAndCredentials

--- a/sbt-codeartifact/src/sbt-test/sbt-codeartifact/do-not-wait-for-skip/project/build.properties
+++ b/sbt-codeartifact/src/sbt-test/sbt-codeartifact/do-not-wait-for-skip/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.5.0

--- a/sbt-codeartifact/src/sbt-test/sbt-codeartifact/resolver/project/build.properties
+++ b/sbt-codeartifact/src/sbt-test/sbt-codeartifact/resolver/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.5.0


### PR DESCRIPTION
Credentials must be added for each CodeArtifact repo resolver. Adds an additional setting that handles this work behind the scenes.