### PR TITLE
Add sts dependency to allow for role-based AWS auth

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -4,7 +4,7 @@ name := "sbt-codeartifact-core"
 
 libraryDependencies ++= Seq(
   "software.amazon.awssdk" % "codeartifact" % "2.17.48",
-  "software.amazon.awssdk" % "sts" % "2.17.48",
+  //"software.amazon.awssdk" % "sts" % "2.17.48",
   "com.lihaoyi" %% "requests" % "0.6.9",
   "com.lihaoyi" %% "os-lib" % "0.7.8",
   "com.lihaoyi" %% "utest" % "0.7.10" % Test

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -4,7 +4,7 @@ name := "sbt-codeartifact-core"
 
 libraryDependencies ++= Seq(
   "software.amazon.awssdk" % "codeartifact" % "2.17.48",
-  //"software.amazon.awssdk" % "sts" % "2.17.48",
+  "software.amazon.awssdk" % "sts" % "2.17.48",
   "com.lihaoyi" %% "requests" % "0.6.9",
   "com.lihaoyi" %% "os-lib" % "0.7.8",
   "com.lihaoyi" %% "utest" % "0.7.10" % Test

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -3,10 +3,11 @@ enablePlugins(SbtPlugin)
 name := "sbt-codeartifact-core"
 
 libraryDependencies ++= Seq(
-  "software.amazon.awssdk" % "codeartifact" % "2.16.10",
-  "com.lihaoyi" %% "requests" % "0.6.5",
-  "com.lihaoyi" %% "os-lib" % "0.7.3",
-  "com.lihaoyi" %% "utest" % "0.7.7" % Test
+  "software.amazon.awssdk" % "codeartifact" % "2.17.48",
+  "software.amazon.awssdk" % "sts" % "2.17.48",
+  "com.lihaoyi" %% "requests" % "0.6.9",
+  "com.lihaoyi" %% "os-lib" % "0.7.8",
+  "com.lihaoyi" %% "utest" % "0.7.10" % Test
 )
 
 testFrameworks += new TestFramework("utest.runner.Framework")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.0
+sbt.version=1.5.5


### PR DESCRIPTION
See https://github.com/gkatzioura/CloudStorageMaven/issues/23 for an explanation of why this should be done to support all kinds of AWS auth. 

In my case, it's building on GitHub CI that is implemented with self-hosted EKS runners, they get all necessary AWS access via a dedicated role. So I can get a CodeArtifact token via AWS CLI, but so far not in sbt-codeartifact as it lacks the role support that is loaded via reflection from the `sts` dependency.