### PR TITLE
Fix binary Scala version detection for Scala 3

### DIFF
--- a/core/src/main/scala/codeartifact/CodeArtifactPackage.scala
+++ b/core/src/main/scala/codeartifact/CodeArtifactPackage.scala
@@ -18,7 +18,10 @@ final case class CodeArtifactPackage(
     val mvn = if (isScalaProject) {
       sbt.CrossVersion
         .partialVersion(scalaVersion)
-        .map { case (maj, min) => List(name, "_", maj, ".", min).mkString }
+        .map {
+          case (3, _)     => s"${name}_3"
+          case (maj, min) => List(name, "_", maj, ".", min).mkString
+        }
         .getOrElse { sys.error("Invalid scalaVersion.") }
     } else {
       name

--- a/core/src/test/scala/codeartifact/CodeArtifactPackageSpec.scala
+++ b/core/src/test/scala/codeartifact/CodeArtifactPackageSpec.scala
@@ -12,19 +12,22 @@ object CodeArtifactPackageSpec extends TestSuite {
 
   val tests = Tests {
     test("asMaven") {
-      test("scala") {
-        basePackage.asMaven ==> "name_3.2"
+      test("scala2") {
+        basePackage.copy(scalaVersion = "2.13.5").asMaven ==> "name_2.13"
+      }
+      test("scala3") {
+        basePackage.asMaven ==> "name_3"
       }
       test("java") {
         basePackage.copy(isScalaProject = false).asMaven ==> "name"
       }
       test("sbt") {
-        basePackage.copy(sbtBinaryVersion = Some("1.0")).asMaven ==> "name_3.2_1.0"
+        basePackage.copy(sbtBinaryVersion = Some("1.0")).asMaven ==> "name_3_1.0"
       }
     }
 
     test("versionPublishPath") {
-      basePackage.versionPublishPath ==> "org/example/name_3.2/1.2.3"
+      basePackage.versionPublishPath ==> "org/example/name_3/1.2.3"
     }
 
     test("mavenMetadata") {


### PR DESCRIPTION
Scala publishes with `_3` suffix, not `_3.1` and alike, so the logic needs adjustment or the wrong files will be created/updated.